### PR TITLE
Flexible http requests

### DIFF
--- a/client/scenes/ClientUI.cs
+++ b/client/scenes/ClientUI.cs
@@ -1,89 +1,84 @@
-using System;
 using Godot;
-using Dictionary = Godot.Collections.Dictionary;
-using Array = Godot.Collections.Array;
 using SharpScape.Game.Dto;
 
 public class ClientUI : Control
 {
-	public Utils _utils;
-	public SharpScapeClient _client;
-	public RichTextLabel _logDest;
-	public LineEdit _lineEdit;
-	public LineEdit _host;
-	public OptionButton _writeMode;
-	private LoginModal _loginModal;
+    public SharpScapeClient _client;
+    public RichTextLabel _logDest;
+    public LineEdit _lineEdit;
+    public LineEdit _host;
+    public OptionButton _writeMode;
+    private LoginModal _loginModal;
 
-	public override void _Ready()
-	{
-		_utils=GetNode<Utils>("/root/Utils");
-		_client = GetNode<SharpScapeClient>("SharpScapeClient");
-		_client.Connect("WriteLine", this, "_OnClientWriteLine");
-		_logDest = GetNode<RichTextLabel>("Panel/VBoxContainer/MainOutput");
-		_lineEdit = GetNode<LineEdit>("Panel/VBoxContainer/Send/LineEdit");
-		_host = GetNode<LineEdit>("Panel/VBoxContainer/Connect/Host");
-		_writeMode = GetNode<OptionButton>("Panel/VBoxContainer/Settings/Mode");
-		_writeMode.Clear();
-		_writeMode.AddItem("BINARY");
-		_writeMode.SetItemMetadata(0, WebSocketPeer.WriteMode.Binary);
-		_writeMode.AddItem("TEXT");
-		_writeMode.SetItemMetadata(1, WebSocketPeer.WriteMode.Text);
-	}
-	private void SpawnLoginModal()
-	{
-		if (IsInstanceValid(_loginModal)) return;
+    public override void _Ready()
+    {
+        _client = GetNode<SharpScapeClient>("SharpScapeClient");
+        _client.Connect("WriteLine", this, "_OnClientWriteLine");
+        _logDest = GetNode<RichTextLabel>("Panel/VBoxContainer/MainOutput");
+        _lineEdit = GetNode<LineEdit>("Panel/VBoxContainer/Send/LineEdit");
+        _host = GetNode<LineEdit>("Panel/VBoxContainer/Connect/Host");
+        _writeMode = GetNode<OptionButton>("Panel/VBoxContainer/Settings/Mode");
+        _writeMode.Clear();
+        _writeMode.AddItem("BINARY");
+        _writeMode.SetItemMetadata(0, WebSocketPeer.WriteMode.Binary);
+        _writeMode.AddItem("TEXT");
+        _writeMode.SetItemMetadata(1, WebSocketPeer.WriteMode.Text);
+    }
+    private void SpawnLoginModal()
+    {
+        if (IsInstanceValid(_loginModal)) return;
 
-		_loginModal = GD.Load<PackedScene>("res://client/scenes/LoginModal.tscn").Instance() as LoginModal;
-		_loginModal.Connect("LoginPayloadReady", this, "_OnLoginPayloadReady");
-		AddChild(_loginModal);
-	}
-	private void _OnLoginPayloadReady()
-	{
-		_utils.Log(_logDest, $"Connecting to host: {_host.Text}");
-		string[] supportedProtocols = {"my-protocol2", "my-protocol", "binary"};
-		_client.ConnectToUrl(_host.Text, supportedProtocols);
-		_client.Websocket.Connect("connection_established", this, "_OnWebsocketConnectionEstablished", flags: (uint)ConnectFlags.Oneshot);
-	}
-	private void _OnWebsocketConnectionEstablished(string protocol)
-	{
-		var wm = (WebSocketPeer.WriteMode)_writeMode.GetSelectedMetadata();
-		_client.SetWriteMode(WebSocketPeer.WriteMode.Text);
-		_client.SendData(new MessageDto(MessageEvent.Login, _loginModal.SecurePayload).ToString());
-		_client.SetWriteMode(wm);
+        _loginModal = GD.Load<PackedScene>("res://client/scenes/LoginModal.tscn").Instance() as LoginModal;
+        _loginModal.Connect("LoginPayloadReady", this, "_OnLoginPayloadReady");
+        AddChild(_loginModal);
+    }
+    private void _OnLoginPayloadReady()
+    {
+        Utils.Log(_logDest, $"Connecting to host: {_host.Text}");
+        string[] supportedProtocols = {"my-protocol2", "my-protocol", "binary"};
+        _client.ConnectToUrl(_host.Text, supportedProtocols);
+        _client.Websocket.Connect("connection_established", this, "_OnWebsocketConnectionEstablished", flags: (uint)ConnectFlags.Oneshot);
+    }
+    private void _OnWebsocketConnectionEstablished(string protocol)
+    {
+        var wm = (WebSocketPeer.WriteMode)_writeMode.GetSelectedMetadata();
+        _client.SetWriteMode(WebSocketPeer.WriteMode.Text);
+        _client.SendData(new MessageDto(MessageEvent.Login, _loginModal.SecurePayload).ToString());
+        _client.SetWriteMode(wm);
 
-		_loginModal.QueueFree();
-	}
-	private void _OnClientWriteLine(string message)
-	{
-		_logDest.AddText($"{message}\n");
-	}
-	public void _OnModeItemSelected(int _id)
-	{
-		_client.SetWriteMode((WebSocketPeer.WriteMode)_writeMode.GetSelectedMetadata());
-	}
-	public void _OnSendPressed()
-	{
-		if(_lineEdit.Text == "")
-		{
-			return;
-		}
-		_utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
-		_client.SendData(new MessageDto(MessageEvent.Message, _lineEdit.Text).ToString());
-		_lineEdit.Text = "";
-	}
-	public void _OnConnectToggled(bool pressed )
-	{
-		if(pressed)
-		{
-			if(_host.Text != "")
-			{
-				SpawnLoginModal();
-			}
-		}
-		else
-		{
-			_writeMode.Disabled = false;
-			_client.DisconnectFromHost();
-		}
-	}
+        _loginModal.QueueFree();
+    }
+    private void _OnClientWriteLine(string message)
+    {
+        _logDest.AddText($"{message}\n");
+    }
+    public void _OnModeItemSelected(int _id)
+    {
+        _client.SetWriteMode((WebSocketPeer.WriteMode)_writeMode.GetSelectedMetadata());
+    }
+    public void _OnSendPressed()
+    {
+        if(_lineEdit.Text == "")
+        {
+            return;
+        }
+        Utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
+        _client.SendData(new MessageDto(MessageEvent.Message, _lineEdit.Text).ToString());
+        _lineEdit.Text = "";
+    }
+    public void _OnConnectToggled(bool pressed )
+    {
+        if(pressed)
+        {
+            if(_host.Text != "")
+            {
+                SpawnLoginModal();
+            }
+        }
+        else
+        {
+            _writeMode.Disabled = false;
+            _client.DisconnectFromHost();
+        }
+    }
 }

--- a/client/scenes/ClientUI.cs
+++ b/client/scenes/ClientUI.cs
@@ -39,7 +39,7 @@ public class ClientUI : Control
 	}
 	private void _OnLoginPayloadReady()
 	{
-		_utils._Log(_logDest, $"Connecting to host: {_host.Text}");
+		_utils.Log(_logDest, $"Connecting to host: {_host.Text}");
 		string[] supportedProtocols = {"my-protocol2", "my-protocol", "binary"};
 		_client.ConnectToUrl(_host.Text, supportedProtocols);
 		_client.Websocket.Connect("connection_established", this, "_OnWebsocketConnectionEstablished", flags: (uint)ConnectFlags.Oneshot);
@@ -67,7 +67,7 @@ public class ClientUI : Control
 		{
 			return;
 		}
-		_utils._Log(_logDest, $"Sending data {_lineEdit.Text}");
+		_utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
 		_client.SendData(new MessageDto(MessageEvent.Message, _lineEdit.Text).ToString());
 		_lineEdit.Text = "";
 	}

--- a/client/scenes/LoginModal.cs
+++ b/client/scenes/LoginModal.cs
@@ -26,7 +26,7 @@ public class LoginModal : Panel
 
         _submit.Disabled = true;
         var keyProvider = this.GetSingleton<ApiPublicKeyProvider>();
-        if (keyProvider.RequestResult == (int)HTTPRequest.Result.NoResponse)
+        if (! keyProvider.IsKeyReady())
             // Enable the _submit button once keyProvider has retrieved the public key from the API
             keyProvider.Connect("PublicKeyReady", _submit, "set", new Godot.Collections.Array { "disabled", false }, (uint)ConnectFlags.Oneshot);
         else

--- a/client/scenes/LoginModal.cs
+++ b/client/scenes/LoginModal.cs
@@ -1,6 +1,7 @@
 using Godot;
 using Newtonsoft.Json;
-using static SharpScape.NodeExtensions;
+using SharpScape.Game.Services;
+using static SharpScape.Game.NodeExtensions;
 
 public class LoginModal : Panel
 {

--- a/client/scripts/ApiPayloadSecurity.cs
+++ b/client/scripts/ApiPayloadSecurity.cs
@@ -16,7 +16,7 @@ namespace SharpScape.Game.Services
         public override async void _Ready()
         {
             var keyProvider = this.GetSingleton<ApiPublicKeyProvider>();
-            if (keyProvider.RequestResult == (int)HTTPRequest.Result.NoResponse)
+            if (! keyProvider.IsKeyReady())
             {
                 await ToSignal(keyProvider, "PublicKeyReady");
             }

--- a/client/scripts/ApiPayloadSecurity.cs
+++ b/client/scripts/ApiPayloadSecurity.cs
@@ -1,3 +1,4 @@
+using Godot;
 using System;
 using System.IO;
 using System.Text;
@@ -5,33 +6,21 @@ using Org.BouncyCastle.OpenSsl;
 using Org.BouncyCastle.Crypto.Engines;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Encodings;
+using static SharpScape.NodeExtensions;
 
-public class ApiPayloadSecurity
+public class ApiPayloadSecurity : Node
 {
     private RsaKeyParameters _apiPublicKey;
 
-    // TODO: load this from external file somehow.
-    // .NET and Godot file loading doesn't play nice with WASM export though
-    // so probably have to use fetch API, which probably means coupling the
-    // request path with the path it's gonna have in the SharpScape frontend.
-    private string _apiPublicKeyPem = @"-----BEGIN PUBLIC KEY-----
-MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA2zE9zZVGdQ2MplGLc43Y
-Tf1/SofwI5uqOsGMP6uvVTPZgxJEQMoxA9954VPss6OR1vpNj7GTSkZeWZhXt3rZ
-ruVVwgoQr0CUA1geMnMEmqeWHTRZa/JwzH/CHoacnzXYIzk96P/Mz7yZwgsYCCFZ
-aHyDwT4bxXpvzhMKmdGGpkIRNdRPEuUtAnMioQ5kO+P8BDUmxeledW1xg2TUotyg
-8uJ0NbsxSrcRKPlGm/n9yeeMN9Vgh9mBoO0Iflytsi8V28VK9pl+JM4cz/dqbjn+
-df/1acu0YalGo4ksnoZ77Olmzf8Y5QfjbGKeFnaGNVFEcHt35R5Cbj68Cv53vfCf
-DuYFewH63vyUlt+AejqPGh+5WvrWnEM7O2cAio/ZIGbqioOLxGHHtSQn9EO1E5Xo
-oOrOw6DT8hNexF5Ti4p3yzg785INzpheCAnydHyLx5Hh0hLX/4LwXfk0cpoPLZFD
-QYrW1ODx86iMS1U9xGd+HhVRYRp4rKB7qj4bZgwPkrQbmT00dJfi9Ar8278/h/fM
-+gOJ5G6mt9Klw/A9kByA0mt+XD7s07kX4sSVmetPHVRnVHP8Um4Yza94paQF5p7G
-ur55ic2lO6xmsVsz1pL79741SwwLLAfg0TlX7He2Rzz7D3IdbIPmS0BzIaDaVAVb
-c718MtMpIdkKSiGzwRKVTjMCAwEAAQ==
------END PUBLIC KEY-----";
-
-    public ApiPayloadSecurity()
+    public override async void _Ready()
     {
-        using (var stringReader = new StringReader(_apiPublicKeyPem))
+        var keyProvider = this.GetSingleton<ApiPublicKeyProvider>();
+        if (keyProvider.RequestResult == (int)HTTPRequest.Result.NoResponse)
+        {
+            await ToSignal(keyProvider, "PublicKeyReady");
+        }
+
+        using (var stringReader = new StringReader(keyProvider.ApiPublicKey))
         {
             var pemReader = new PemReader(stringReader);
             _apiPublicKey = (RsaKeyParameters) pemReader.ReadObject();
@@ -40,6 +29,9 @@ c718MtMpIdkKSiGzwRKVTjMCAwEAAQ==
 
     public string EncryptPayload(string payload)
     {
+        if (_apiPublicKey is null)
+            throw new MissingFieldException("API Public Key was not initialized");
+
         var engine = new Pkcs1Encoding(new RsaEngine());
         engine.Init(forEncryption: true, _apiPublicKey);
 

--- a/client/scripts/ApiPublicKeyProvider.cs
+++ b/client/scripts/ApiPublicKeyProvider.cs
@@ -1,50 +1,53 @@
 using Godot;
 using System.Text;
 
-public class ApiPublicKeyProvider : Node
+namespace SharpScape.Game.Services
 {
-    [Signal] delegate void PublicKeyReady();
-
-    public string ApiPublicKey;
-    public int RequestResult = (int)HTTPRequest.Result.NoResponse;
-    public int ResponseCode = 0;
-
-    private HTTPRequest _http = new HTTPRequest();
-
-    public override void _Ready()
+    public class ApiPublicKeyProvider : ServiceNode
     {
-        AddChild(_http);
-        _http.Connect("request_completed", this, "_OnHttpRequestCompleted");
+        [Signal] delegate void PublicKeyReady();
 
-        var domain = $"https://{Utils.GetSharpScapeDomain()}/api/publickey";
-        GD.Print($"Fetching API public key from {domain}");
-        var err = _http.Request(domain, sslValidateDomain: false);
-        if (err != Error.Ok)
-        {
-            GD.Print($"Couldn't request API public key: {err}");
-        }
-    }
+        public string ApiPublicKey;
+        public int RequestResult = (int)HTTPRequest.Result.NoResponse;
+        public int ResponseCode = 0;
 
-    private void _OnHttpRequestCompleted(int result, int responseCode, string[] headers, byte[] body)
-    {
-        if (result != (int)HTTPRequest.Result.Success)
-        {
-            GD.Print($"Error fetching API public key: {result}");
-        }
+        private HTTPRequest _http = new HTTPRequest();
 
-        if (200 <= responseCode && responseCode < 300)
+        public override void _Ready()
         {
-            ApiPublicKey = Encoding.UTF8.GetString(body);
-            GD.Print("Got API public key successfully.");
-            EmitSignal(nameof(PublicKeyReady));
-        }
-        else
-        {
-            GD.Print($"Error fetching API public key: Server response {responseCode}");
+            AddChild(_http);
+            _http.Connect("request_completed", this, "_OnHttpRequestCompleted");
+
+            var domain = $"https://{Utils.GetSharpScapeDomain()}/api/publickey";
+            GD.Print($"Fetching API public key from {domain}");
+            var err = _http.Request(domain, sslValidateDomain: false);
+            if (err != Error.Ok)
+            {
+                GD.Print($"Couldn't request API public key: {err}");
+            }
         }
 
-        RequestResult = result;
-        ResponseCode = responseCode;
-        _http.QueueFree();
+        private void _OnHttpRequestCompleted(int result, int responseCode, string[] headers, byte[] body)
+        {
+            if (result != (int)HTTPRequest.Result.Success)
+            {
+                GD.Print($"Error fetching API public key: {result}");
+            }
+
+            if (200 <= responseCode && responseCode < 300)
+            {
+                ApiPublicKey = Encoding.UTF8.GetString(body);
+                GD.Print("Got API public key successfully.");
+                EmitSignal(nameof(PublicKeyReady));
+            }
+            else
+            {
+                GD.Print($"Error fetching API public key: Server response {responseCode}");
+            }
+
+            RequestResult = result;
+            ResponseCode = responseCode;
+            _http.QueueFree();
+        }
     }
 }

--- a/client/scripts/ApiPublicKeyProvider.cs
+++ b/client/scripts/ApiPublicKeyProvider.cs
@@ -1,0 +1,50 @@
+using Godot;
+using System.Text;
+
+public class ApiPublicKeyProvider : Node
+{
+    [Signal] delegate void PublicKeyReady();
+
+    public string ApiPublicKey;
+    public int RequestResult = (int)HTTPRequest.Result.NoResponse;
+    public int ResponseCode = 0;
+
+    private HTTPRequest _http = new HTTPRequest();
+
+    public override void _Ready()
+    {
+        AddChild(_http);
+        _http.Connect("request_completed", this, "_OnHttpRequestCompleted");
+
+        var domain = $"https://{Utils.GetSharpScapeDomain()}/api/publickey";
+        GD.Print($"Fetching API public key from {domain}");
+        var err = _http.Request(domain, sslValidateDomain: false);
+        if (err != Error.Ok)
+        {
+            GD.Print($"Couldn't request API public key: {err}");
+        }
+    }
+
+    private void _OnHttpRequestCompleted(int result, int responseCode, string[] headers, byte[] body)
+    {
+        if (result != (int)HTTPRequest.Result.Success)
+        {
+            GD.Print($"Error fetching API public key: {result}");
+        }
+
+        if (200 <= responseCode && responseCode < 300)
+        {
+            ApiPublicKey = Encoding.UTF8.GetString(body);
+            GD.Print("Got API public key successfully.");
+            EmitSignal(nameof(PublicKeyReady));
+        }
+        else
+        {
+            GD.Print($"Error fetching API public key: Server response {responseCode}");
+        }
+
+        RequestResult = result;
+        ResponseCode = responseCode;
+        _http.QueueFree();
+    }
+}

--- a/client/scripts/SharpScapeClient.cs
+++ b/client/scripts/SharpScapeClient.cs
@@ -11,13 +11,11 @@ public class SharpScapeClient : Node
     [Signal] delegate void WriteLine(string what);
 
     public WebSocketClient Websocket;
-    private Utils _utils;
     private WebSocketPeer.WriteMode _writeMode;
     public int lastConnectedClient;
 
     public override void _Ready()
     {
-        _utils=GetNode<Utils>("/root/Utils");
         _writeMode = WebSocketPeer.WriteMode.Binary;
         lastConnectedClient = 0;
     }
@@ -81,8 +79,9 @@ public class SharpScapeClient : Node
 
         EmitSignal(nameof(WriteLine), $"Received data. BINARY: {!isString}");
 
-        var packetText = (string) _utils.DecodeData(packet, isString);
+        var packetText = (string) Utils.DecodeData(packet, isString);
         var serverMessageDto = MessageDto.FromJson(packetText);
+        if (serverMessageDto is null) return;
 
         switch(serverMessageDto.Event)
         {
@@ -114,7 +113,7 @@ public class SharpScapeClient : Node
     public void SendData(string data)
     {
         Websocket.GetPeer(1).SetWriteMode(_writeMode);
-        Websocket.GetPeer(1).PutPacket(_utils.EncodeData(data, _writeMode));
+        Websocket.GetPeer(1).PutPacket(Utils.EncodeData(data, _writeMode));
     }
 
     public void SetWriteMode(WebSocketPeer.WriteMode mode)

--- a/development.tscn
+++ b/development.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://server/scenes/server.tscn" type="PackedScene" id=1]
 [ext_resource path="res://client/scenes/ClientUI.tscn" type="PackedScene" id=2]
 
-[node name="Node2D" type="Node2D"]
+[node name="Dev" type="Node2D"]
 
 [node name="Client" parent="." instance=ExtResource( 2 )]
 anchor_right = 0.0

--- a/project.godot
+++ b/project.godot
@@ -14,10 +14,6 @@ config/name="SharpScape"
 run/main_scene="res://main.tscn"
 config/icon="res://icon.png"
 
-[autoload]
-
-Utils="*res://shared/Utils.cs"
-
 [display]
 
 window/stretch/mode="2d"

--- a/server/scenes/ServerUI.cs
+++ b/server/scenes/ServerUI.cs
@@ -38,18 +38,18 @@ public class ServerUI : Control
             var port = (int)_port.Value;
             if(_server.Listen(port, supportedProtocols) == Error.Ok)
             {
-                _utils._Log(_logDest, $"Listing on port {port}");
+                _utils.Log(_logDest, $"Listing on port {port}");
             }
             else
             {
-                _utils._Log(_logDest, $"Error  listening on port {port}");
+                _utils.Log(_logDest, $"Error  listening on port {port}");
             }
         }
         else
         {
             _server.Stop();
             _writeMode.Disabled = false;
-            _utils._Log(_logDest, "SharpScapeServer stopped");
+            _utils.Log(_logDest, "SharpScapeServer stopped");
         }
     }
 
@@ -59,7 +59,7 @@ public class ServerUI : Control
         {
             return;
         }
-        _utils._Log(_logDest, $"Sending data {_lineEdit.Text}");
+        _utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
         _server.SendData(_lineEdit.Text);
         _lineEdit.Text = "";
     }

--- a/server/scenes/ServerUI.cs
+++ b/server/scenes/ServerUI.cs
@@ -5,7 +5,6 @@ using Array = Godot.Collections.Array;
 
 public class ServerUI : Control
 {
-    public Utils _utils;
     public SharpScapeServer _server;
 
     public SpinBox _port;
@@ -15,7 +14,6 @@ public class ServerUI : Control
 
     public override void _Ready()
     {
-        _utils=GetNode<Utils>("/root/Utils");
         _server = GetNode<SharpScapeServer>("SharpScapeServer");
         _port = GetNode<SpinBox>("Panel/VBoxContainer/HBoxContainer/Port");
         _lineEdit = GetNode<LineEdit>("Panel/VBoxContainer/HBoxContainer3/LineEdit");
@@ -38,18 +36,18 @@ public class ServerUI : Control
             var port = (int)_port.Value;
             if(_server.Listen(port, supportedProtocols) == Error.Ok)
             {
-                _utils.Log(_logDest, $"Listing on port {port}");
+                Utils.Log(_logDest, $"Listing on port {port}");
             }
             else
             {
-                _utils.Log(_logDest, $"Error  listening on port {port}");
+                Utils.Log(_logDest, $"Error  listening on port {port}");
             }
         }
         else
         {
             _server.Stop();
             _writeMode.Disabled = false;
-            _utils.Log(_logDest, "SharpScapeServer stopped");
+            Utils.Log(_logDest, "SharpScapeServer stopped");
         }
     }
 
@@ -59,7 +57,7 @@ public class ServerUI : Control
         {
             return;
         }
-        _utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
+        Utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
         _server.SendData(_lineEdit.Text);
         _lineEdit.Text = "";
     }

--- a/server/scripts/HttpAuthentication.cs
+++ b/server/scripts/HttpAuthentication.cs
@@ -1,12 +1,10 @@
 using Godot;
 using System.Text;
 
-public class HttpAuthentication : Node
+public class HttpAuthentication : HTTPRequest
 {
     [Signal] delegate void ApiLoginSuccess(int clientId, string gameAvatarInfoDto);
     [Signal] delegate void ApiLoginFailure(int clientId);
-
-    private HTTPRequest _request = new HTTPRequest();
 
     public int ClientId;
 
@@ -17,13 +15,12 @@ public class HttpAuthentication : Node
 
     public override void _Ready()
     {
-        AddChild(_request);
-        _request.Connect("request_completed", this, "_OnHttpRequestCompleted");
+        Connect("request_completed", this, "_OnHttpRequestCompleted");
     }
 
     public void Authenticate(string payload)
     {
-        var err = _request.Request($"https://{Utils.SharpScapeDomain}/api/game/login",
+        var err = Request($"https://{Utils.GetSharpScapeDomain()}/api/game/login",
             customHeaders: new[] {"Content-Type: application/json"},
             sslValidateDomain: false,
             method: HTTPClient.Method.Post,

--- a/server/scripts/HttpAuthentication.cs
+++ b/server/scripts/HttpAuthentication.cs
@@ -1,7 +1,7 @@
 using Godot;
 using System.Text;
 
-public class Http : Node
+public class HttpAuthentication : Node
 {
     [Signal] delegate void ApiLoginSuccess(int clientId, string gameAvatarInfoDto);
     [Signal] delegate void ApiLoginFailure(int clientId);
@@ -10,7 +10,7 @@ public class Http : Node
 
     public int ClientId;
 
-    public Http(int clientId)
+    public HttpAuthentication(int clientId)
     {
         ClientId = clientId;
     }
@@ -23,7 +23,7 @@ public class Http : Node
 
     public void Authenticate(string payload)
     {
-        var err = _request.Request("https://localhost:7193/api/game/login",
+        var err = _request.Request($"https://{Utils.SharpScapeDomain}/api/game/login",
             customHeaders: new[] {"Content-Type: application/json"},
             sslValidateDomain: false,
             method: HTTPClient.Method.Post,

--- a/server/scripts/SharpScapeServer.cs
+++ b/server/scripts/SharpScapeServer.cs
@@ -10,7 +10,6 @@ public class SharpScapeServer : Node
     public RichTextLabel _logDest;
     public int lastConnectedClient;
 
-    private Utils _utils;
     private WebSocketServer _server;
     private ClientsById _clients;
     private WebSocketPeer.WriteMode _writeMode;
@@ -28,7 +27,6 @@ public class SharpScapeServer : Node
     public override void _Ready()
     {
         _logDest = GetParent().GetNode<RichTextLabel>("Panel/VBoxContainer/RichTextLabel");
-        _utils=GetNode<Utils>("/root/Utils");
         _clients = new ClientsById(){};
         _writeMode = WebSocketPeer.WriteMode.Binary;
         lastConnectedClient = 0;
@@ -51,7 +49,7 @@ public class SharpScapeServer : Node
     public void _ClientCloseRequest(int id, string code, string reason)
     {
         GD.Print(reason == "Bye bye!");
-        _utils.Log(_logDest, $"Client {id} close code: {code}, reason: {reason}");
+        Utils.Log(_logDest, $"Client {id} close code: {code}, reason: {reason}");
     }
 
     public void _ClientConnected(int id, string protocol)
@@ -59,12 +57,12 @@ public class SharpScapeServer : Node
         _clients.Add(id,_server.GetPeer(id));
         _clients[id].SetWriteMode(_writeMode);
         lastConnectedClient = id;
-        _utils.Log(_logDest, $"Client {id} connected with protocol {protocol}");
+        Utils.Log(_logDest, $"Client {id} connected with protocol {protocol}");
     }
 
     public void _ClientDisconnected(int id, bool clean = true)
     {
-        _utils.Log(_logDest, $"Client {id} disconnected. Was clean: {clean}");
+        Utils.Log(_logDest, $"Client {id} disconnected. Was clean: {clean}");
         if(_clients.ContainsKey(id))
         {
             _clients.Remove(id);
@@ -75,11 +73,13 @@ public class SharpScapeServer : Node
     {
         var packet = _server.GetPeer(id).GetPacket();
         var isString = _server.GetPeer(id).WasStringPacket();
-        _utils.Log(_logDest, $"Data from {id} BINARY: {!isString}: {_utils.DecodeData(packet, isString)}");
+        Utils.Log(_logDest, $"Data from {id} BINARY: {!isString}: {Utils.DecodeData(packet, isString)}");
         if (isString)
         {
             var payloadJson = System.Text.Encoding.UTF8.GetString(packet);
             var msgObject = MessageDto.FromJson(payloadJson);
+            if (msgObject is null) return;
+
             switch(msgObject.Event)
             {
             case MessageEvent.Login:
@@ -122,7 +122,7 @@ public class SharpScapeServer : Node
     {
         foreach(int id in _clients.Keys)
         {
-            _server.GetPeer(id).PutPacket(_utils.EncodeData(data, _writeMode));
+            _server.GetPeer(id).PutPacket(Utils.EncodeData(data, _writeMode));
         }
     }
 

--- a/server/scripts/SharpScapeServer.cs
+++ b/server/scripts/SharpScapeServer.cs
@@ -51,7 +51,7 @@ public class SharpScapeServer : Node
     public void _ClientCloseRequest(int id, string code, string reason)
     {
         GD.Print(reason == "Bye bye!");
-        _utils._Log(_logDest, $"Client {id} close code: {code}, reason: {reason}");
+        _utils.Log(_logDest, $"Client {id} close code: {code}, reason: {reason}");
     }
 
     public void _ClientConnected(int id, string protocol)
@@ -59,12 +59,12 @@ public class SharpScapeServer : Node
         _clients.Add(id,_server.GetPeer(id));
         _clients[id].SetWriteMode(_writeMode);
         lastConnectedClient = id;
-        _utils._Log(_logDest, $"Client {id} connected with protocol {protocol}");
+        _utils.Log(_logDest, $"Client {id} connected with protocol {protocol}");
     }
 
     public void _ClientDisconnected(int id, bool clean = true)
     {
-        _utils._Log(_logDest, $"Client {id} disconnected. Was clean: {clean}");
+        _utils.Log(_logDest, $"Client {id} disconnected. Was clean: {clean}");
         if(_clients.ContainsKey(id))
         {
             _clients.Remove(id);
@@ -75,7 +75,7 @@ public class SharpScapeServer : Node
     {
         var packet = _server.GetPeer(id).GetPacket();
         var isString = _server.GetPeer(id).WasStringPacket();
-        _utils._Log(_logDest, $"Data from {id} BINARY: {!isString}: {_utils.DecodeData(packet, isString)}");
+        _utils.Log(_logDest, $"Data from {id} BINARY: {!isString}: {_utils.DecodeData(packet, isString)}");
         if (isString)
         {
             var payloadJson = System.Text.Encoding.UTF8.GetString(packet);
@@ -101,7 +101,7 @@ public class SharpScapeServer : Node
 
     private void TryAuthenticateClient(int clientId, string loginDto)
     {
-        var http = new Http(clientId);
+        var http = new HttpAuthentication(clientId);
         http.Connect("ApiLoginSuccess", this, "_OnApiLoginSuccess");
         http.Connect("ApiLoginFailure", this, "_OnApiLoginFailure");
         AddChild(http);

--- a/shared/MessageDto.cs
+++ b/shared/MessageDto.cs
@@ -37,18 +37,25 @@ namespace SharpScape.Game.Dto
 
         // Json serialization stuff:
 
-        private static JsonSerializerSettings _settings = new JsonSerializerSettings() {
+        private static JsonSerializerSettings _jsonSettings = new JsonSerializerSettings() {
             DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate
         };
 
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this, _settings);
+            return JsonConvert.SerializeObject(this, _jsonSettings);
         }
 
         public static MessageDto FromJson(string json)
         {
-            return JsonConvert.DeserializeObject<MessageDto>(json, _settings);
+            try
+            {
+                return JsonConvert.DeserializeObject<MessageDto>(json, _jsonSettings);
+            }
+            catch (JsonSerializationException)
+            {
+                return null;
+            }
         }
     }
 }

--- a/shared/NodeExtensions.cs
+++ b/shared/NodeExtensions.cs
@@ -1,0 +1,32 @@
+using Godot;
+using System.Linq;
+
+namespace SharpScape
+{
+    public static class NodeExtensions
+    {
+        public static T GetSingleton<T>(this Node self) where T : Node, new()
+        {
+            var singleton = self.GetTree().Root.GetChildren().OfType<T>().FirstOrDefault();
+            if (singleton is null)
+            {
+                singleton = new T();
+                singleton.Name = singleton.GetType().ToString();
+                self.GetTree().Root.AddChild(singleton);
+            }
+            return singleton;
+        }
+
+        public static T GetScoped<T>(this Node self) where T : Node, new()
+        {
+            var scoped = self.GetTree().CurrentScene.GetChildren().OfType<T>().FirstOrDefault();
+            if (scoped is null)
+            {
+                scoped = new T();
+                scoped.Name = scoped.GetType().ToString();
+                self.GetTree().CurrentScene.AddChild(scoped);
+            }
+            return scoped;
+        }
+    }
+}

--- a/shared/NodeExtensions.cs
+++ b/shared/NodeExtensions.cs
@@ -1,11 +1,12 @@
 using Godot;
 using System.Linq;
+using SharpScape.Game.Services;
 
-namespace SharpScape
+namespace SharpScape.Game
 {
     public static class NodeExtensions
     {
-        public static T GetSingleton<T>(this Node self) where T : Node, new()
+        public static T GetSingleton<T>(this Node self) where T : ServiceNode, new()
         {
             var singleton = self.GetTree().Root.GetChildren().OfType<T>().FirstOrDefault();
             if (singleton is null)
@@ -17,7 +18,7 @@ namespace SharpScape
             return singleton;
         }
 
-        public static T GetScoped<T>(this Node self) where T : Node, new()
+        public static T GetScoped<T>(this Node self) where T : ServiceNode, new()
         {
             var scoped = self.GetTree().CurrentScene.GetChildren().OfType<T>().FirstOrDefault();
             if (scoped is null)

--- a/shared/ServiceNode.cs
+++ b/shared/ServiceNode.cs
@@ -1,0 +1,8 @@
+using Godot;
+
+namespace SharpScape.Game.Services
+{
+    public abstract class ServiceNode : Node
+    {
+    }
+}

--- a/shared/Utils.cs
+++ b/shared/Utils.cs
@@ -6,16 +6,28 @@ public class Utils
 	{
 		if (OS.HasFeature("JavaScript"))
 		{	// this is an HTML5 export
-			var parentLocation = (string) JavaScript.Eval("window.parent.location.href");
-			var location = (string) JavaScript.Eval("window.location.href");
-			if (parentLocation != location)
+			var window = JavaScript.GetInterface("window");
+			var location = (JavaScriptObject) window.Get("location");
+			var parentWindow = (JavaScriptObject) window.Get("parent");
+			var parentLocation = (JavaScriptObject) parentWindow.Get("location");
+
+			var href = (string) location.Get("href");
+			var parentHref = (string) parentLocation.Get("href");
+
+			if (href != parentHref)
 			{	// we are inside an <iframe>
-				return (string) JavaScript.Eval("window.parent.location.host");
+				return (string) parentLocation.Get("host");
 			}
-			else {
-				return "localhost:7193";
+			else if ((string) location.Get("hostname") == "localhost")
+			{	// this is a toplevel test of an HTML5 export, probably being served on a different port than SharpScape
+				return "localhost:7193";	// this only works if SharpScape's Api has Cors enabled
+			}
+			else
+			{	// this is a production toplevel HTML5 export
+				return (string) location.Get("host");
 			}
 		}
+
 		var domain = OS.GetEnvironment("SHARPSCAPE_DOMAIN");
 		return domain.Length > 0
 			? domain

--- a/shared/Utils.cs
+++ b/shared/Utils.cs
@@ -4,6 +4,18 @@ public class Utils
 {
 	public static string GetSharpScapeDomain()
 	{
+		if (OS.HasFeature("JavaScript"))
+		{	// this is an HTML5 export
+			var parentLocation = (string) JavaScript.Eval("window.parent.location.href");
+			var location = (string) JavaScript.Eval("window.location.href");
+			if (parentLocation != location)
+			{	// we are inside an <iframe>
+				return (string) JavaScript.Eval("window.parent.location.host");
+			}
+			else {
+				return "localhost:7193";
+			}
+		}
 		var domain = OS.GetEnvironment("SHARPSCAPE_DOMAIN");
 		return domain.Length > 0
 			? domain

--- a/shared/Utils.cs
+++ b/shared/Utils.cs
@@ -3,6 +3,17 @@ using Godot;
 
 public class Utils : Node
 {
+	public static string SharpScapeDomain = "localhost:7193";
+
+	public Utils()
+	{
+		var domain = OS.GetEnvironment("SHARPSCAPE_DOMAIN");
+		if (domain.Length > 0)
+			SharpScapeDomain = domain;
+
+        GD.Print($"SharpScape Domain is set to {SharpScapeDomain}");
+	}
+
 	public byte[] EncodeData(string data, WebSocketPeer.WriteMode mode)
 	{
 		if(mode == WebSocketPeer.WriteMode.Text)
@@ -19,7 +30,7 @@ public class Utils : Node
 		}
 		return GD.Bytes2Var(data);
 	}
-	public void _Log(RichTextLabel node, string msg)
+	public void Log(RichTextLabel node, string msg)
 	{
 		GD.Print(msg);
 		node.AddText(GD.Str(msg) + "\n");

--- a/shared/Utils.cs
+++ b/shared/Utils.cs
@@ -1,20 +1,16 @@
-using System;
 using Godot;
 
-public class Utils : Node
+public class Utils
 {
-	public static string SharpScapeDomain = "localhost:7193";
-
-	public Utils()
+	public static string GetSharpScapeDomain()
 	{
 		var domain = OS.GetEnvironment("SHARPSCAPE_DOMAIN");
-		if (domain.Length > 0)
-			SharpScapeDomain = domain;
-
-        GD.Print($"SharpScape Domain is set to {SharpScapeDomain}");
+		return domain.Length > 0
+			? domain
+			: "localhost:7193";
 	}
 
-	public byte[] EncodeData(string data, WebSocketPeer.WriteMode mode)
+	public static byte[] EncodeData(string data, WebSocketPeer.WriteMode mode)
 	{
 		if(mode == WebSocketPeer.WriteMode.Text)
 		{
@@ -22,7 +18,8 @@ public class Utils : Node
 		}
 		return GD.Var2Bytes(data);
 	}
-	public object DecodeData(byte[] data, bool isString)
+
+	public static object DecodeData(byte[] data, bool isString)
 	{
 		if(isString)
 		{
@@ -30,9 +27,10 @@ public class Utils : Node
 		}
 		return GD.Bytes2Var(data);
 	}
-	public void Log(RichTextLabel node, string msg)
+
+	public static void Log(RichTextLabel printTarget, string msg)
 	{
 		GD.Print(msg);
-		node.AddText(GD.Str(msg) + "\n");
+		printTarget.AddText(GD.Str(msg) + "\n");
 	}
 }


### PR DESCRIPTION
Enables the game processes to use the appropriate host for HTTP requests.
 - Native processes will use an environment variable `SHARPSCAPE_DOMAIN`, or fallback to `localhost:7193`.
 - WASM processes will check to see if it runs in an `<iframe>` using JavaScript to check its window location:
   - Running in an `<iframe>` will use the enclosing window's host: this is the desired behavior in production.
   - ~~Running in a toplevel browser window currently indicates testing, and will use `localhost:7193`.  This can be changed later since we might want to allow the game to be played in full-window instead of in an `<iframe>`.  In that case we will have to find another way to indicate whether the WASM export is in test mode or not (probably just check whether the window's location domain is `localhost` or not).~~
   - **Edit**: Running in a toplevel browser window will assume it is being served by SharpScape and will use its current `window.location.host`, unless the `hostname` is `localhost` which indicates testing and will return `localhost:7193`.