### PR TITLE
Let a duplicate connection kill the previous one

### DIFF
--- a/server/scripts/SharpScapeServer.cs
+++ b/server/scripts/SharpScapeServer.cs
@@ -117,10 +117,12 @@ public class SharpScapeServer : Node
     private void _OnApiLoginSuccess(int clientId, string responseBody)
     {
         var playerInfo = Utils.FromJson<PlayerInfo>(responseBody);
-        if (_players.Values.Any(v => v.UserInfo.Id == playerInfo.UserInfo.Id))
+        int? loggedInPlayer = _players.Keys.FirstOrDefault(k => _players[k].UserInfo.Id == playerInfo.UserInfo.Id);
+        if (loggedInPlayer != null)
         {
-            _server.DisconnectPeer(clientId, 1011, "Duplicate login attempted");
-            return;
+            _server.DisconnectPeer((int)loggedInPlayer, 1011, "Killing duplicate login (ghost?)");
+            _clients.Remove((int)loggedInPlayer);
+            _players.Remove((int)loggedInPlayer);
         }
         SendData(Utils.ToJson(new MessageDto(MessageEvent.Login, responseBody, clientId)));
         foreach (int id in _players.Keys)


### PR DESCRIPTION
Instead of denying a new connection for the same user, kill the previous connection and use the new one