### PR TITLE
Include the KeyId in signature validation

### DIFF
--- a/server/scripts/SharpScapeServer.cs
+++ b/server/scripts/SharpScapeServer.cs
@@ -91,7 +91,7 @@ public class SharpScapeServer : Node
                         KeyId = uniqueSecret.KeyId,
                         Payload = uniqueSecret.Payload,
                         Timestamp = (int)timestamp,
-                        Signature = _crypto.Sign($"{uniqueSecret.Payload}.{timestamp.ToString()}")
+                        Signature = _crypto.Sign($"{uniqueSecret.KeyId}.{uniqueSecret.Payload}.{timestamp.ToString()}")
                     };
                     TryAuthenticateClient(id, Utils.ToJson(loginDto));
                     break;


### PR DESCRIPTION
Accidentally left the KeyId unsigned when adding it to `ApiLoginDto`