### PR TITLE
Bugfix: Login modal no longer crashes the game

### DIFF
--- a/client/scenes/ClientUI.cs
+++ b/client/scenes/ClientUI.cs
@@ -13,7 +13,7 @@ public class ClientUI : Control
     public override void _Ready()
     {
         _client = GetNode<SharpScapeClient>("SharpScapeClient");
-        _client.Connect("WriteLine", this, "_OnClientWriteLine");
+        _client.Connect("WriteLine", this, nameof(_OnClientWriteLine));
         _logDest = GetNode<RichTextLabel>("Panel/VBoxContainer/MainOutput");
         _lineEdit = GetNode<LineEdit>("Panel/VBoxContainer/Send/LineEdit");
         _host = GetNode<LineEdit>("Panel/VBoxContainer/Connect/Host");
@@ -29,7 +29,7 @@ public class ClientUI : Control
         if (IsInstanceValid(_loginModal)) return;
 
         _loginModal = GD.Load<PackedScene>("res://client/scenes/LoginModal.tscn").Instance() as LoginModal;
-        _loginModal.Connect("LoginPayloadReady", this, "_OnLoginPayloadReady");
+        _loginModal.Connect("LoginPayloadReady", this, nameof(_OnLoginPayloadReady));
         AddChild(_loginModal);
     }
     private void _OnLoginPayloadReady()
@@ -37,16 +37,28 @@ public class ClientUI : Control
         Utils.Log(_logDest, $"Connecting to host: {_host.Text}");
         string[] supportedProtocols = {"my-protocol2", "my-protocol", "binary"};
         _client.ConnectToUrl(_host.Text, supportedProtocols);
-        _client.Websocket.Connect("connection_established", this, "_OnWebsocketConnectionEstablished", flags: (uint)ConnectFlags.Oneshot);
+        _client.Websocket.Connect("connection_established", this, nameof(_OnWebsocketConnectionEstablished), flags: (uint)ConnectFlags.Oneshot);
+        _client.Websocket.Connect("connection_error",
+                                  target: _loginModal,
+                                  method: "ErrorRetry",
+                                  binds: new Godot.Collections.Array { "Websocket connection failure" },
+                                  flags: (uint)ConnectFlags.Oneshot);
     }
     private void _OnWebsocketConnectionEstablished(string protocol)
     {
-        var wm = (WebSocketPeer.WriteMode)_writeMode.GetSelectedMetadata();
-        _client.SetWriteMode(WebSocketPeer.WriteMode.Text);
-        _client.SendData(Utils.ToJson(new MessageDto(MessageEvent.Login, _loginModal.SecurePayload)));
-        _client.SetWriteMode(wm);
-
-        _loginModal.QueueFree();
+        _client.TryAuthenticate(Utils.ToJson(new MessageDto(MessageEvent.Login, _loginModal.SecurePayload)));
+        _client.Connect("AuthenticationResult", this, nameof(_OnClientAuthResult), flags: (uint)ConnectFlags.Oneshot);
+    }
+    private void _OnClientAuthResult(bool success)
+    {
+        if (success)
+        {
+            _loginModal.QueueFree();
+        }
+        else
+        {
+            _loginModal.ErrorRetry("Authentication failed. Try again");
+        }
     }
     private void _OnClientWriteLine(string message)
     {

--- a/client/scenes/LoginModal.cs
+++ b/client/scenes/LoginModal.cs
@@ -10,6 +10,7 @@ public class LoginModal : Panel
 
     private MPClientCrypto _crypto;
 
+    private Label _statusline;
     private LineEdit _username;
     private LineEdit _password;
     private Button _submit;
@@ -17,6 +18,8 @@ public class LoginModal : Panel
 
     public override void _Ready()
     {
+        _statusline = GetNode<Label>("Statusline");
+
         _username = GetNode<LineEdit>("Username");
         _username.GrabFocus();
 
@@ -24,21 +27,33 @@ public class LoginModal : Panel
 
         _submit = GetNode<Button>("LoginSubmit");
         _submit.Connect("pressed", this, "_OnLoginSubmitPressed");
-
-        _submit.Disabled = true;
-        _crypto = this.GetTransient<MPClientCrypto>();
-        if (! _crypto.keyProvider.IsKeyReady())
-            // Enable the _submit button once keyProvider has retrieved the public key from the API
-            _crypto.keyProvider.Connect("KeyReady", _submit, "set", new Godot.Collections.Array { "disabled", false }, (uint)ConnectFlags.Oneshot);
-        else
-            _submit.Disabled = false;
     }
 
     private void _OnLoginSubmitPressed()
     {
+        _submit.Disabled = true;
+        _submit.Text = "Logging in...";
+        _crypto = this.GetTransient<MPClientCrypto>();
+        _crypto.KeyProvider.Connect("KeyReady", this, nameof(_OnCryptoKeyReady), flags: (uint)ConnectFlags.Oneshot);
+    }
+
+    private void _OnCryptoKeyReady(bool success)
+    {
+        if (!success)
+        {
+            ErrorRetry("Connection error. Retry");
+            return;
+        }
         var payloadJson = Utils.ToJson(new LoginPayload(_username.Text, _password.Text));
         SecurePayload = _crypto.EncryptPayload(payloadJson);
         EmitSignal(nameof(LoginPayloadReady));
+    }
+
+    public void ErrorRetry(string message)
+    {
+        _statusline.Text = message;
+        _submit.Text = "Retry";
+        _submit.Disabled = false;
     }
 
     internal class LoginPayload : JsonSerializable

--- a/client/scenes/LoginModal.tscn
+++ b/client/scenes/LoginModal.tscn
@@ -17,7 +17,7 @@ margin_bottom = 244.0
 custom_styles/panel = SubResource( 1 )
 script = ExtResource( 1 )
 
-[node name="Label" type="Label" parent="."]
+[node name="Statusline" type="Label" parent="."]
 anchor_left = 0.5
 anchor_right = 0.5
 margin_left = -276.0

--- a/client/scripts/ApiPublicKeyProvider.cs
+++ b/client/scripts/ApiPublicKeyProvider.cs
@@ -13,7 +13,7 @@ namespace SharpScape.Game.Services
             public string X509Pub { get; set; }
         }
 
-        [Signal] delegate void KeyReady();
+        [Signal] delegate void KeyReady(bool success);
 
         public HTTPRequest.Result RequestResult = HTTPRequest.Result.NoResponse;
         public HTTPClient.ResponseCode ResponseCode = HTTPClient.ResponseCode.ImATeapot;
@@ -55,11 +55,12 @@ namespace SharpScape.Game.Services
                 var json = Encoding.UTF8.GetString(body);
                 TransientKey = Utils.FromJson<ApiTransientKey>(json);
                 GD.Print("Got API transient key successfully.");
-                EmitSignal(nameof(KeyReady));
+                EmitSignal(nameof(KeyReady), true);
             }
             else
             {
                 GD.Print($"Error fetching API public key: Server response {responseCode}");
+                EmitSignal(nameof(KeyReady), false);
             }
 
             _http.QueueFree();

--- a/client/scripts/MPClientCrypto.cs
+++ b/client/scripts/MPClientCrypto.cs
@@ -12,30 +12,30 @@ namespace SharpScape.Game.Services
 {
     public class MPClientCrypto : ServiceNode
     {
-        public ApiTransientKeyProvider keyProvider;
+        public ApiTransientKeyProvider KeyProvider;
 
         public override async void _Ready()
         {
-            keyProvider = this.GetTransient<ApiTransientKeyProvider>();
-            await ToSignal(keyProvider, "KeyReady");
+            KeyProvider = this.GetTransient<ApiTransientKeyProvider>();
+            await ToSignal(KeyProvider, "KeyReady");
         }
 
         public string EncryptPayload(string payload)
         {
-            if (keyProvider.TransientKey is null)
+            if (KeyProvider.TransientKey is null)
                 throw new MissingFieldException("API transient key was not initialized");
 
             var data = Encoding.UTF8.GetBytes(payload);
             AesEncrypt(data, out byte[] securePayload, out byte[] aesKey);
-            byte[] secureKey = RsaEncrypt(aesKey, keyProvider.TransientKey.X509Pub);
-
-            QueueFree();
+            byte[] secureKey = RsaEncrypt(aesKey, KeyProvider.TransientKey.X509Pub);
 
             var uniqueSecret = new UniqueSecret() {
-                KeyId = keyProvider.TransientKey.KeyId,
+                KeyId = KeyProvider.TransientKey.KeyId,
                 SecureKey = Convert.ToBase64String(secureKey),
                 Payload = Convert.ToBase64String(securePayload)
             };
+
+            QueueFree();
 
             return Convert.ToBase64String(Encoding.UTF8.GetBytes(Utils.ToJson(uniqueSecret)));
         }

--- a/server/scenes/ServerUI.cs
+++ b/server/scenes/ServerUI.cs
@@ -58,7 +58,7 @@ public class ServerUI : Control
             return;
         }
         Utils.Log(_logDest, $"Sending data {_lineEdit.Text}");
-        _server.SendData(_lineEdit.Text);
+        _server.Broadcast(_lineEdit.Text);
         _lineEdit.Text = "";
     }
 

--- a/shared/Data/MessageDto.cs
+++ b/shared/Data/MessageDto.cs
@@ -6,6 +6,7 @@ namespace SharpScape.Game.Dto
 {
     public static class MessageEvent
     {
+        public const string Identify = "Identify";
         public const string Login = "Login";
         public const string Logout = "Logout";
         public const string ListPlayer = "ListPlayer";


### PR DESCRIPTION
Previously, there were several conditions under which logging in would fail, but leave the modal present, yet it was programmed to access objects that had been freed from memory.  This is no longer the case: the several different modes of connection and authentication failure have been accounted for, the user is prompted to retry, and its dependencies are refreshed.