### PR TITLE
Bugfixes: Login modal, Takeover logins, Logouts

### DIFF
--- a/client/scenes/MainLogin/MainLogin.cs
+++ b/client/scenes/MainLogin/MainLogin.cs
@@ -20,12 +20,11 @@ public class MainLogin : Control
     private void _DelayedReady()
     {
         _client = this.GetSingleton<SharpScapeClient>();
-        _client.Websocket.Connect("connection_established", this, nameof(_OnWebsocketConnectionEstablished), flags: (uint)ConnectFlags.Oneshot);
+        _client.Websocket.Connect("connection_established", this, nameof(_OnWebsocketConnectionEstablished));
         _client.Websocket.Connect("connection_error",
                                   target: _loginModal,
                                   method: "ErrorRetry",
-                                  binds: new Godot.Collections.Array { "Websocket connection failure" },
-                                  flags: (uint)ConnectFlags.Oneshot);
+                                  binds: new Godot.Collections.Array { "Websocket connection failure" });
     }
 
     private void _OnLoginPayloadReady()
@@ -37,7 +36,7 @@ public class MainLogin : Control
     {
         _client.SetWriteMode(WebSocketPeer.WriteMode.Text);
         _client.TryAuthenticate(Utils.ToJson(new MessageDto(MessageEvent.Login, _loginModal.SecurePayload)));
-        _client.Connect("AuthenticationResult", this, nameof(_OnClientAuthResult), flags: (uint)ConnectFlags.Oneshot);
+        _client.Connect("AuthenticationResult", this, nameof(_OnClientAuthResult));
     }
     private void _OnClientAuthResult(bool success)
     {

--- a/client/scripts/ApiPublicKeyProvider.cs
+++ b/client/scripts/ApiPublicKeyProvider.cs
@@ -61,6 +61,7 @@ namespace SharpScape.Game.Services
             {
                 GD.Print($"Error fetching API public key: Server response {responseCode}");
                 EmitSignal(nameof(KeyReady), false);
+                QueueFree();
             }
 
             _http.QueueFree();

--- a/client/scripts/SharpScapeClient.cs
+++ b/client/scripts/SharpScapeClient.cs
@@ -1,10 +1,10 @@
 using Godot;
-using Array = Godot.Collections.Array;
-using SharpScape.Game.Dto;
-using PlayersById = System.Collections.Generic.Dictionary<int, SharpScape.Game.Dto.PlayerInfo>;
 using System;
-using SharpScape.Game.Services;
 using System.Linq;
+using SharpScape.Game.Dto;
+using SharpScape.Game.Services;
+using Array = Godot.Collections.Array;
+using PlayersById = System.Collections.Generic.Dictionary<int, SharpScape.Game.Dto.PlayerInfo>;
 
 public class SharpScapeClient : NetworkServiceNode
 {
@@ -59,6 +59,7 @@ public class SharpScapeClient : NetworkServiceNode
         }
         else
         {
+            _players.Clear();
             GetTree().ChangeScene("res://client/scenes/MainLogin/MainLogin.tscn");
         }
     }
@@ -162,8 +163,11 @@ public class SharpScapeClient : NetworkServiceNode
             case MessageEvent.Logout:
             {
                 EmitSignal(nameof(WriteLog), $"* {who} logged out");
-                EmitSignal(nameof(PlayerLogoutEvent), incoming.Data);
-                if (_players.ContainsKey(incoming.ClientId)) _players.Remove(incoming.ClientId);
+                if (_players.ContainsKey(incoming.ClientId))
+                {
+                    EmitSignal(nameof(PlayerLogoutEvent), Utils.ToJson(_players[incoming.ClientId]));
+                    _players.Remove(incoming.ClientId);
+                }
                 break;
             }
             default:

--- a/server/scripts/SharpScapeServer.cs
+++ b/server/scripts/SharpScapeServer.cs
@@ -1,11 +1,11 @@
 using Godot;
 using System;
 using System.Linq;
+using System.Text;
 using SharpScape.Game.Dto;
 using SharpScape.Game.Services;
 using ClientsById = System.Collections.Generic.Dictionary<int, Godot.WebSocketPeer>;
 using PlayersById = System.Collections.Generic.Dictionary<int, SharpScape.Game.Dto.PlayerInfo>;
-using System.Text;
 
 public class SharpScapeServer : NetworkServiceNode
 {
@@ -158,6 +158,9 @@ public class SharpScapeServer : NetworkServiceNode
         try
         {
             int loggedInPlayer = _players.Keys.First(k => _players[k].UserInfo.Id == playerInfo.UserInfo.Id);
+            playerInfo = _players[loggedInPlayer];
+            responseBody = Utils.ToJson(playerInfo);
+            _players.Remove(loggedInPlayer);
             _server.DisconnectPeer(loggedInPlayer, 1011, "Killing duplicate login (ghost?)");
         }
         catch (InvalidOperationException)

--- a/shared/Scenes/World/World.cs
+++ b/shared/Scenes/World/World.cs
@@ -1,9 +1,8 @@
 using Godot;
+using System.Linq;
 using SharpScape.Game;
 using SharpScape.Game.Dto;
 using SharpScape.Game.Services;
-using System;
-using System.Linq;
 
 public class World : Node2D
 {


### PR DESCRIPTION
- Login modal would get into a stuck state if connections weren't fully successful. Now it properly resets.
- Duplicate (Takeover) logins would leave ghost avatars in the game world. These get freed.
- When another player logs out, invalid data was sent over a signal, causing the remaining connected clients to crash.