### PR TITLE
Use character sprite specified in database, or default

### DIFF
--- a/shared/Scenes/GameAvatar/GameAvatar.tscn
+++ b/shared/Scenes/GameAvatar/GameAvatar.tscn
@@ -1,27 +1,34 @@
 [gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://shared/Scenes/GameAvatar/Sprites/default.tres" type="SpriteFrames" id=1]
 [ext_resource path="res://shared/Scenes/GameAvatar/GameAvatar.cs" type="Script" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
-extents = Vector2( 32.5, 32 )
+extents = Vector2( 19, 8 )
 
 [node name="GameAvatar" type="KinematicBody2D" groups=["Players"]]
 script = ExtResource( 2 )
 
-[node name="Sprite" type="Sprite" parent="."]
-texture = ExtResource( 1 )
-
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2( -0.5, 0 )
+position = Vector2( 0, -4 )
 shape = SubResource( 1 )
 
 [node name="PlayerCamera" type="Camera2D" parent="."]
+position = Vector2( 0, -28 )
 
 [node name="Username" type="Label" parent="."]
 margin_left = -120.0
-margin_top = 28.0
 margin_right = 121.0
-margin_bottom = 42.0
+margin_bottom = 14.0
 text = "username"
 align = 1
+
+[node name="CharacterSprites" type="Position2D" parent="."]
+
+[node name="Default" type="AnimatedSprite" parent="CharacterSprites"]
+visible = false
+position = Vector2( 0, -28 )
+scale = Vector2( 2, 2 )
+frames = ExtResource( 1 )
+animation = "idle"
+playing = true

--- a/shared/Scenes/GameAvatar/Sprites/default.tres
+++ b/shared/Scenes/GameAvatar/Sprites/default.tres
@@ -1,121 +1,121 @@
 [gd_resource type="SpriteFrames" load_steps=26 format=2]
 
-[ext_resource path="res://shared/Assets/Idle (32x32).png" type="Texture" id=1]
-[ext_resource path="res://shared/Assets/Run (32x32).png" type="Texture" id=2]
+[ext_resource path="res://shared/Assets/Run (32x32).png" type="Texture" id=1]
+[ext_resource path="res://shared/Assets/Idle (32x32).png" type="Texture" id=2]
 
 [sub_resource type="AtlasTexture" id=1]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 0, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=2]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 32, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=3]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 64, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=4]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 96, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=5]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 128, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=6]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 160, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=7]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 192, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=8]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 224, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=9]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 256, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=10]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 288, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=11]
 flags = 4
-atlas = ExtResource( 1 )
+atlas = ExtResource( 2 )
 region = Rect2( 320, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=12]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 0, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=13]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 32, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=14]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 64, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=15]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 96, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=16]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 128, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=17]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 160, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=18]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 192, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=19]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 224, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=20]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 256, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=21]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 288, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=22]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 320, 0, 32, 32 )
 
 [sub_resource type="AtlasTexture" id=23]
 flags = 4
-atlas = ExtResource( 2 )
+atlas = ExtResource( 1 )
 region = Rect2( 352, 0, 32, 32 )
 
 [resource]
@@ -123,10 +123,10 @@ animations = [ {
 "frames": [ SubResource( 1 ), SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 10 ), SubResource( 11 ) ],
 "loop": true,
 "name": "idle",
-"speed": 5.0
+"speed": 18.0
 }, {
 "frames": [ SubResource( 12 ), SubResource( 13 ), SubResource( 14 ), SubResource( 15 ), SubResource( 16 ), SubResource( 17 ), SubResource( 18 ), SubResource( 19 ), SubResource( 20 ), SubResource( 21 ), SubResource( 22 ), SubResource( 23 ) ],
 "loop": true,
 "name": "run",
-"speed": 5.0
+"speed": 18.0
 } ]

--- a/shared/Scenes/World/World.cs
+++ b/shared/Scenes/World/World.cs
@@ -39,6 +39,7 @@ public class World : Node2D
         avatar.UserId = player.UserInfo.Id;
         avatar.Username = player.UserInfo.Username;
         avatar.GlobalPosition = new Vector2(player.GlobalPositionX, player.GlobalPositionY);
+        avatar.SetAnimatedSpriteFrames(player.SpriteName);
 
         EmitSignal(nameof(AvatarSpawned), avatar);
         return avatar;

--- a/shared/Scenes/World/World.tscn
+++ b/shared/Scenes/World/World.tscn
@@ -4,10 +4,14 @@
 [ext_resource path="res://shared/Resources/tileset.tres" type="TileSet" id=2]
 [ext_resource path="res://shared/Scenes/World/World.cs" type="Script" id=3]
 
-[node name="World" type="Node2D"]
+[node name="World" type="YSort"]
 script = ExtResource( 3 )
 
-[node name="TileMap" type="TileMap" parent="."]
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+layer = -5
+follow_viewport_enable = true
+
+[node name="TileMap" type="TileMap" parent="CanvasLayer"]
 position = Vector2( -483, -545 )
 tile_set = ExtResource( 2 )
 cell_size = Vector2( 32, 32 )


### PR DESCRIPTION
The game will now select the character sprite from the list of `AnimatedSprite` *children* under GameAvatar's `CharacterSprites` node.  The value of `SharpScape.Game.Dto.PlayerInfo.SpriteName` must match the *node name* (case insensitive) in order to select the sprite, or else it will default to the one Wei made earlier.

- Resource files (SpriteFrames resources, `*.tres`) go under `shared/GameAvatar/Sprites/{sprite name}.tres`
- A matching `AnimatedSprite` *node* must be added to `GameAvatar.tscn` under `GameAvatar/CharacterSprites/{sprite name}`
  - by default it should be set to invisible