### PR TITLE
Bugfix: Free network service on world exit

### DIFF
--- a/shared/Scenes/World/World.cs
+++ b/shared/Scenes/World/World.cs
@@ -25,6 +25,11 @@ public class World : Node2D
             flags: (uint)ConnectFlags.Oneshot);
     }
 
+    public override void _ExitTree()
+    {
+        this.GetSingleton<NetworkServiceNode>().QueueFree();
+    }
+
     public GameAvatar SpawnGameAvatar(string playerInfo)
     {
         var player = Utils.FromJson<PlayerInfo>(playerInfo);


### PR DESCRIPTION
In some cases, logging out and switching to a different account was
leaving a ghost avatar in the client's world from the last login.
Freeing the NetworkServiceNode singleton deletes all memory from any
previous session and prevents it from poisoning next sessions.